### PR TITLE
fix: handle patient list response

### DIFF
--- a/src/components/modals/SessionModal.tsx
+++ b/src/components/modals/SessionModal.tsx
@@ -23,7 +23,7 @@ interface SessionModalProps {
   onClose: () => void;
   onSave: (data: SessionFormData) => void;
   userRole: Role;
-  clients: Client[];
+  clients?: Client[];
   editingData?: Session | null; // Dados da sessão que está sendo editada
   onDateClickData?: { date: Date; time: string } | null; // Dados para pré-preencher
 }
@@ -33,7 +33,7 @@ export function SessionModal({
   onClose,
   onSave,
   userRole,
-  clients,
+  clients = [],
   editingData,
   onDateClickData,
 }: SessionModalProps) {

--- a/src/pages/PacienteDetalhesPage.tsx
+++ b/src/pages/PacienteDetalhesPage.tsx
@@ -139,7 +139,7 @@ export function PacienteDetalhesPage({ clientId, onBack, currentUser }: Paciente
         onClose={closeModal}
         onSave={handleSaveSession}
         userRole={currentUser.role}
-        clients={[client]} // Passa apenas o cliente atual para o modal
+        clients={client ? [client] : []} // Passa apenas o cliente atual para o modal
         editingData={editingItem}
       />
     </main>

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -2,18 +2,34 @@
 import api from './api';
 import { Client } from '@/types';
 
-// O tipo 'any' aqui é um placeholder. O ideal é que o backend retorne um objeto de paginação
-export const getPatients = async (page: number, limit: number, searchTerm: string): Promise<{ data: Client[], total: number }> => {
+// Busca pacientes no backend e garante um formato consistente de retorno.
+// Alguns backends podem retornar um array diretamente enquanto outros
+// utilizam um objeto com as propriedades `data` e `total`.
+export const getPatients = async (
+  page: number,
+  limit: number,
+  searchTerm: string
+): Promise<{ data: Client[]; total: number }> => {
   const response = await api.get('/patients', {
     params: {
       page,
       limit,
       search: searchTerm,
-    }
+    },
   });
-  // Adapte a resposta conforme o que seu backend retorna.
-  // Exemplo: return { data: response.data.clients, total: response.data.totalCount };
-  return response.data; 
+
+  const respData = response.data;
+
+  // Se a API retorna um array simples de pacientes
+  if (Array.isArray(respData)) {
+    return { data: respData, total: respData.length };
+  }
+
+  // Caso contrário, assume-se que já possui a estrutura { data, total }
+  return {
+    data: respData.data ?? [],
+    total: respData.total ?? respData.data?.length ?? 0,
+  };
 };
 
 export const getPatientById = async (id: number): Promise<Client> => {


### PR DESCRIPTION
## Summary
- handle varying patient API responses
- guard session modal against missing clients
- ensure patient detail modal only receives valid client array

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f676af054832f9fb6999e1a345dc5