### PR TITLE
Define missing button variants for consistent styling

### DIFF
--- a/src/components/modals/FuncionarioModal.tsx
+++ b/src/components/modals/FuncionarioModal.tsx
@@ -471,7 +471,7 @@ export function FuncionarioModal({ open, onClose, onSave }: FuncionarioModalProp
           <Button variant="ghost" type="button" onClick={onClose}>
             Cancelar
           </Button>
-          <Button type="submit" disabled={!isValid}>
+          <Button variant="primary" type="submit" disabled={!isValid}>
             Salvar Cadastro
           </Button>
         </div>

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -85,7 +85,7 @@ export function ProfileModal({ open, onClose }: ProfileModalProps) {
                 {errors.confirmPassword && <p className="text-sm text-red-500 mt-1">{errors.confirmPassword.message}</p>}
               </div>
               <div className="flex justify-end pt-4">
-                <Button type="submit">Salvar Alterações</Button>
+                <Button variant="primary" type="submit">Salvar Alterações</Button>
               </div>
             </form>
           </TabsContent>

--- a/src/components/modals/SessionModal.tsx
+++ b/src/components/modals/SessionModal.tsx
@@ -474,7 +474,7 @@ export function SessionModal({
           <Button variant="ghost" type="button" onClick={internalClose}>
             Cancelar
           </Button>
-          <Button type="submit">Salvar</Button>
+          <Button variant="primary" type="submit">Salvar</Button>
         </div>
       </form>
     </Dialog>

--- a/src/pages/AgendaPage.tsx
+++ b/src/pages/AgendaPage.tsx
@@ -123,7 +123,7 @@ export function AgendaPage({ currentUser }: AgendaPageProps) {
               </button>
             ))}
           </div>
-          <Button className="primary" onClick={() => { setSelectedSession(null); setDateClickData(null); setIsModalOpen(true); }}>
+          <Button variant="primary" onClick={() => { setSelectedSession(null); setDateClickData(null); setIsModalOpen(true); }}>
             <Plus className="mr-2 h-4 w-4" /> Novo Agendamento
           </Button>
         </div>

--- a/src/pages/DefinicoesPage.tsx
+++ b/src/pages/DefinicoesPage.tsx
@@ -119,7 +119,7 @@ export function DefinicoesPage({ currentUser, setCurrentUser }: DefinicoesPagePr
                 </div>
               </CardContent>
               <div className="flex justify-end p-6 pt-2">
-                <Button type="submit">Salvar Clínica</Button>
+                <Button variant="primary" type="submit">Salvar Clínica</Button>
               </div>
             </form>
           </Card>
@@ -170,7 +170,7 @@ export function DefinicoesPage({ currentUser, setCurrentUser }: DefinicoesPagePr
               </div>
             </CardContent>
             <div className="flex justify-end p-6 pt-2">
-              <Button type="submit">Salvar Perfil</Button>
+              <Button variant="primary" type="submit">Salvar Perfil</Button>
             </div>
           </form>
         </Card>

--- a/src/pages/FuncionariosPage.tsx
+++ b/src/pages/FuncionariosPage.tsx
@@ -30,7 +30,7 @@ export function FuncionariosPage({ employees, setEmployees }: FuncionariosPagePr
         <main className="p-6">
             <div className="flex justify-between items-center mb-6">
                 <h2 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Funcionários</h2>
-                <Button onClick={() => setIsModalOpen(true)}><Plus className="mr-2 h-4 w-4" /> Novo Funcionário</Button>
+                <Button variant="primary" onClick={() => setIsModalOpen(true)}><Plus className="mr-2 h-4 w-4" /> Novo Funcionário</Button>
             </div>
             <Card>
                 <CardContent className="!p-0">

--- a/src/pages/PacienteDetalhesPage.tsx
+++ b/src/pages/PacienteDetalhesPage.tsx
@@ -96,7 +96,7 @@ export function PacienteDetalhesPage({ clientId, onBack, currentUser }: Paciente
         <div className="lg:col-span-2">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-xl font-bold text-slate-800 dark:text-slate-100">Histórico de Sessões</h3>
-            <Button onClick={openModalForNew}><Plus className="mr-2 h-4 w-4" /> Registrar Nova Sessão</Button>
+            <Button variant="primary" onClick={openModalForNew}><Plus className="mr-2 h-4 w-4" /> Registrar Nova Sessão</Button>
           </div>
             <div className="space-y-4">
               {historyItems.map((item: any) => (


### PR DESCRIPTION
## Summary
- add primary variant to buttons missing styling across pages
- align modal save actions with primary button variant

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2198db62c832f8248664116b46ade