### PR TITLE
Remove hour column borders in weekly view

### DIFF
--- a/src/pages/agenda/components/WeeklyView.tsx
+++ b/src/pages/agenda/components/WeeklyView.tsx
@@ -69,7 +69,10 @@ export function WeeklyView({ calendar, sessions, onDateClick, onAppointmentClick
             {/* Coluna de horários */}
             <div className="flex flex-col">
               {hours.map(hour => (
-                <div key={hour} className="h-16 text-sm text-slate-500 text-right pr-4 border-b border-slate-200 dark:border-slate-700 -translate-y-2">
+                <div
+                  key={hour}
+                  className="h-16 pb-px text-sm text-slate-500 text-right pr-4 -translate-y-2"
+                >
                   {`${hour}:00`}
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- remove border styles from hour labels in weekly agenda
- add padding to keep time text aligned with day grid

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2201914ec832fb7caff9e01e06281